### PR TITLE
Fix RestConnector to throw exception that include error message

### DIFF
--- a/Hpe.Nga.Api.Core/Connector/Exceptions/MqmRestException.cs
+++ b/Hpe.Nga.Api.Core/Connector/Exceptions/MqmRestException.cs
@@ -12,10 +12,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Hpe.Nga.Api.Core.Connector.Exceptions
 {
@@ -29,7 +26,7 @@ namespace Hpe.Nga.Api.Core.Connector.Exceptions
             get { return statusCode; }
         }
 
-        public MqmRestException(RestExceptionInfo exceptionInfo, HttpStatusCode statusCode)
+        public MqmRestException(RestExceptionInfo exceptionInfo, HttpStatusCode statusCode, Exception innerException) : base(exceptionInfo.description, innerException)
         {
             this.exceptionInfo = exceptionInfo;
             this.statusCode = statusCode;

--- a/Hpe.Nga.Api.Core/Connector/Exceptions/ServerUnavailableException.cs
+++ b/Hpe.Nga.Api.Core/Connector/Exceptions/ServerUnavailableException.cs
@@ -18,7 +18,15 @@ using System.Threading.Tasks;
 
 namespace Hpe.Nga.Api.Core.Connector.Exceptions
 {
+
+    [Serializable]
     public class ServerUnavailableException : Exception
     {
+        public ServerUnavailableException() { }
+        public ServerUnavailableException(string message) : base(message) { }
+        public ServerUnavailableException(string message, Exception inner) : base(message, inner) { }
+        protected ServerUnavailableException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }


### PR DESCRIPTION
When Octane server respond with HTTP error RestConnector now parse the server response and throws MqmRestException with the parsed message and the original exception to allow debug trace of the root cause.