### PR TITLE
Switch BaseEntity ID to be string while still supporting int for now

### DIFF
--- a/Hpe.Nga.Api.Core.Tests/AttachmentTests.cs
+++ b/Hpe.Nga.Api.Core.Tests/AttachmentTests.cs
@@ -90,7 +90,7 @@ namespace Hpe.Nga.Api.Core.Tests
             defect.Parent = getWorkItemRoot();
             Defect created = entityService.Create<Defect>(workspaceContext, defect, TestHelper.NameFields);
             Assert.AreEqual<String>(name, created.Name);
-            Assert.IsTrue(created.Id > 0);
+            Assert.IsTrue(!string.IsNullOrEmpty(created.Id));
             return created;
 
         }

--- a/Hpe.Nga.Api.Core.Tests/DefectTests.cs
+++ b/Hpe.Nga.Api.Core.Tests/DefectTests.cs
@@ -232,7 +232,7 @@ namespace Hpe.Nga.Api.Core.Tests
             defect.Parent = getWorkItemRoot();
             Defect created = entityService.Create<Defect>(workspaceContext, defect, new string[] { "name" });
             Assert.AreEqual<String>(name, created.Name);
-            Assert.IsTrue(created.Id > 0);
+            Assert.IsTrue(!string.IsNullOrEmpty(created.Id));
             return created;
 
         }

--- a/Hpe.Nga.Api.Core.Tests/EntityIdTests.cs
+++ b/Hpe.Nga.Api.Core.Tests/EntityIdTests.cs
@@ -1,0 +1,102 @@
+﻿using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using Hpe.Nga.Api.Core.Entities;
+
+namespace Hpe.Nga.Api.Core.Tests
+{
+    [TestClass]
+    public class EntityIdTests
+    {
+        [TestMethod]
+        public void EqualsEntityId()
+        {
+            EntityId a = new EntityId("hello");
+            EntityId b = new EntityId("hello");
+
+            Assert.AreEqual(a, b);
+        }
+
+        [TestMethod]
+        public void NotEqualsEntityId()
+        {
+            EntityId a = new EntityId("hello");
+            EntityId b = new EntityId("goodbye");
+
+            Assert.AreNotEqual(a, b);
+        }
+
+        [TestMethod]
+        public void EntityIdToString()
+        {
+            EntityId entityId = new EntityId("123");
+            string stringValue = entityId.ToString();
+
+            Assert.AreEqual("123", stringValue);
+        }
+
+        [TestMethod]
+        public void EqualsOperator()
+        {
+            EntityId a = new EntityId("1abc2");
+            EntityId b = new EntityId("1abc2");
+
+            Assert.IsTrue(a == b);
+        }
+
+        [TestMethod]
+        public void NotEqualsOperator()
+        {
+            EntityId a = new EntityId("1abc2");
+            EntityId b = new EntityId("9xyz8");
+
+            Assert.IsTrue(a != b);
+        }
+
+        [TestMethod]
+        public void KeyInMap()
+        {
+            EntityId id1 = new EntityId("1111");
+            EntityId id2 = new EntityId("2222");
+
+            var map = new Dictionary<EntityId, int>
+            {
+                { id1, 20 }
+            };
+
+            // Retrieve by EntityId
+            Assert.AreEqual(20, map[id1]);
+
+            // Ensure key is not found
+            Assert.IsFalse(map.ContainsKey(id2));
+        }
+
+        [TestMethod]
+        public void ConvertIEnumerableOfEntityIdToListOfLong()
+        {
+            List<Test> l = new List<Test>
+            {
+                new Test("123"),
+                new Test("456")
+            };
+
+            List<long> assignedWorkspaceRoles = l.Select(p => p.Id).ToList<long>();
+
+            Assert.AreEqual(assignedWorkspaceRoles.Count, 2);
+        }
+
+        [TestMethod]
+        public void ConvertIEnumerableOfEntityIdToListOfString()
+        {
+            List<Test> l = new List<Test>
+            {
+                new Test("123"),
+                new Test("456")
+            };
+
+            List<string> assignedWorkspaceRoles = l.Select(p => p.Id).ToList<string>();
+
+            Assert.AreEqual(assignedWorkspaceRoles.Count, 2);
+        }
+    }
+}

--- a/Hpe.Nga.Api.Core.Tests/Hpe.Nga.Api.Core.Tests.csproj
+++ b/Hpe.Nga.Api.Core.Tests/Hpe.Nga.Api.Core.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ConnectionTests.cs" />
     <Compile Include="AttachmentTests.cs" />
     <Compile Include="QueryBuilderTests.cs" />
+    <Compile Include="EntityIdTests.cs" />
     <Compile Include="WorkItemTests.cs" />
     <Compile Include="TestManualTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Hpe.Nga.Api.Core.Tests/ReleaseTests.cs
+++ b/Hpe.Nga.Api.Core.Tests/ReleaseTests.cs
@@ -50,7 +50,7 @@ namespace Hpe.Nga.Api.Core.Tests
             List<String> fields = new List<string>();
             fields.Add(Release.NAME_FIELD);
             Release release = entityService.GetById<Release>(workspaceContext, created.Id, fields);
-            Assert.AreEqual<long>(release.Id, created.Id);
+            Assert.AreEqual(release.Id, created.Id);
             return release;
         }
 
@@ -168,7 +168,7 @@ namespace Hpe.Nga.Api.Core.Tests
             EntityListResult<Sprint> result = entityService.Get<Sprint>(workspaceContext, queryPhrases, fields);
             Assert.IsTrue(result.data.Count >= 1);
             Release releaseFromSprint = result.data[0].Release;
-            Assert.AreEqual<long>(release.Id, releaseFromSprint.Id);
+            Assert.AreEqual(release.Id, releaseFromSprint.Id);
         }
 
 

--- a/Hpe.Nga.Api.Core.Tests/SharedspaceUserTests.cs
+++ b/Hpe.Nga.Api.Core.Tests/SharedspaceUserTests.cs
@@ -83,7 +83,7 @@ namespace Hpe.Nga.Api.Core.Tests
             List<String> fields = new List<string> { SharedspaceUser.NAME_FIELD, SharedspaceUser.WORKSPACE_ROLES_FIELD };
             SharedspaceUser updatedUser = entityService.GetById<SharedspaceUser>(sharedSpaceContext, createdUser.Id, fields);
 
-            List<long> assignedWorkspaceRoles = updatedUser.WorkspaceRoles.data.Select(p => p.Id).ToList<long>();
+            List<EntityId> assignedWorkspaceRoles = updatedUser.WorkspaceRoles.data.Select(p => p.Id).ToList();
             Assert.IsTrue(assignedWorkspaceRoles.Contains(sharedSpaceAdminRole.Id));
         }
 
@@ -116,7 +116,7 @@ namespace Hpe.Nga.Api.Core.Tests
             List<String> fields = new List<string> { SharedspaceUser.NAME_FIELD, SharedspaceUser.WORKSPACE_ROLES_FIELD };
             SharedspaceUser updatedUser = entityService.GetById<SharedspaceUser>(sharedSpaceContext, createdUser.Id, fields);
 
-            List<long> assignedWorkspaceRoles = updatedUser.WorkspaceRoles.data.Select(p => p.Id).ToList<long>();
+            List<EntityId> assignedWorkspaceRoles = updatedUser.WorkspaceRoles.data.Select(p => p.Id).ToList();
             Assert.IsTrue(assignedWorkspaceRoles.Contains(sharedSpaceAdminRole.Id));
             Assert.IsTrue(assignedWorkspaceRoles.Count > 1);
         }

--- a/Hpe.Nga.Api.Core.Tests/StoryTests.cs
+++ b/Hpe.Nga.Api.Core.Tests/StoryTests.cs
@@ -80,7 +80,7 @@ namespace Hpe.Nga.Api.Core.Tests
             story.Parent = WORK_ITEM_ROOT;
             Story created = entityService.Create<Story>(workspaceContext, story, TestHelper.NameSubtypeFields);
             Assert.AreEqual<String>(name, created.Name);
-            Assert.IsTrue(created.Id > 0);
+            Assert.IsTrue(!string.IsNullOrEmpty(created.Id));
             return created;
         }
     }

--- a/Hpe.Nga.Api.Core.Tests/TestManualTests.cs
+++ b/Hpe.Nga.Api.Core.Tests/TestManualTests.cs
@@ -89,7 +89,7 @@ namespace Hpe.Nga.Api.Core.Tests
 
             TestManual created = entityService.Create<TestManual>(workspaceContext, test, TestHelper.NameSubtypeFields);
             Assert.AreEqual<String>(name, created.Name);
-            Assert.IsTrue(created.Id > 0);
+            Assert.IsTrue(!string.IsNullOrEmpty(created.Id));
             return created;
         }
     }

--- a/Hpe.Nga.Api.Core/Entities/Base/Attachment.cs
+++ b/Hpe.Nga.Api.Core/Entities/Base/Attachment.cs
@@ -28,7 +28,7 @@ namespace Hpe.Nga.Api.Core.Entities.Base
 
         }
 
-        public Attachment(long id)
+        public Attachment(EntityId id)
         {
             this.Id = id;
         }

--- a/Hpe.Nga.Api.Core/Entities/Base/BaseEntity.cs
+++ b/Hpe.Nga.Api.Core/Entities/Base/BaseEntity.cs
@@ -37,7 +37,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public BaseEntity(long id)
+        public BaseEntity(EntityId id)
             : base()
         {
             Id = id;
@@ -54,15 +54,23 @@ namespace Hpe.Nga.Api.Core.Entities
 
         #region Base Properties
 
-        public long Id
+        public EntityId Id
         {
             get
             {
-                return GetLongValue(ID_FIELD, 0);
+                object id = GetValue(ID_FIELD);
+                if (id is EntityId)
+                {
+                    return (EntityId)id;
+                }
+                else
+                {
+                    return new EntityId(id.ToString());
+                }
             }
             set
             {
-                SetLongValue(ID_FIELD, value);
+                SetValue(ID_FIELD, value);
             }
 
         }

--- a/Hpe.Nga.Api.Core/Entities/Base/EntityId.cs
+++ b/Hpe.Nga.Api.Core/Entities/Base/EntityId.cs
@@ -1,0 +1,116 @@
+﻿using System;
+
+namespace Hpe.Nga.Api.Core.Entities
+{
+    /// <summary>
+    /// Represents the idnetifier of an entity.
+    /// </summary>
+    /// <remarks>
+    /// Octane used to use <see cref="long"/> as type of entity ID but since change to use <see cref="string"/>.
+    /// This class allow backward compatability with code that use <see cref="long"/> while allowing to transition to <see cref="string"/>.
+    /// </remarks>
+    public sealed class EntityId
+    {
+        private string value;
+
+        public EntityId()
+        {
+        }
+
+        public EntityId(string value)
+        {
+            this.value = value ?? throw new ArgumentNullException("value");
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                // null never equals to another instance.
+                return false;
+            }
+
+            if (GetType() == obj.GetType())
+            {
+                return value.Equals(((EntityId)obj).value);
+            }
+            else if (obj.GetType() == typeof(string))
+            {
+                return value.Equals(obj);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return value.GetHashCode();
+        }
+
+        public static bool operator ==(EntityId a, EntityId b)
+        {
+            if (ReferenceEquals(a, null) || ReferenceEquals(b, null))
+            {
+                // both null which means they are equals.
+                return true;
+            }
+
+            if (ReferenceEquals(a, null))
+            {
+                // a is null while b not so they are not requals.
+                return false;
+            }
+
+            EntityId aa = (EntityId)a;
+            return aa.Equals(b);
+        }
+
+        public static bool operator !=(EntityId a, EntityId b)
+        {
+            return !(a == b);
+        }
+
+        public override string ToString()
+        {
+            return value;
+        }
+
+        /// <summary>
+        /// Convert EntityId to string.
+        /// </summary>
+        /// <param name="entityId"></param>
+        public static implicit operator string(EntityId entityId)
+        {
+            return entityId.value;
+        }
+
+        /// <summary>
+        /// Convert string to EntityId.
+        /// </summary>
+        /// <param name="entityId"></param>
+        public static implicit operator EntityId(string entityId)
+        {
+            return new EntityId(entityId);
+        }
+
+        /// <summary>
+        /// Convert EntityId to long while issuing obsolete warning.
+        /// </summary>
+        /// <param name="entityId"></param>
+        [Obsolete("Octane is now using string as EntityId. In the next version of this SDK it will not be possible to using long id. Please change your code to use string instead of long.")]
+        public static implicit operator long(EntityId entityId)
+        {
+            return Convert.ToInt64(entityId.value);
+        }
+
+        /// <summary>
+        /// Convert long to EntityId while issuing obsolete warning.
+        /// </summary>
+        /// <param name="entityId"></param>
+        [Obsolete("Octane is now using string as EntityId. In the next version of this SDK it will not be possible to using long id. Please change your code to use string instead of long.")]
+        public static implicit operator EntityId(long entityId)
+        {
+            return new EntityId(entityId.ToString());
+        }
+    }
+}

--- a/Hpe.Nga.Api.Core/Entities/Base/EntityIdExtensions.cs
+++ b/Hpe.Nga.Api.Core/Entities/Base/EntityIdExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+
+namespace Hpe.Nga.Api.Core.Entities
+{
+    public static class EntityIdExtensions
+    {
+        public static List<T> ToList<T>(this IEnumerable<EntityId> entityIds)
+        {
+            if (typeof(T).IsAssignableFrom(typeof(long)))
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                return entityIds.Select(id => (long)id).ToList() as List<T>;
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+            else if (typeof(T).IsAssignableFrom(typeof(string)))
+            {
+                return entityIds.Select(id => (string)id).ToList() as List<T>;
+            }
+            else
+            {
+                throw new System.Exception("IEnumerable<EntityId> cannot be converted to List of " + typeof(T));
+            }
+        }
+    }
+}

--- a/Hpe.Nga.Api.Core/Entities/Releases/Milestone.cs
+++ b/Hpe.Nga.Api.Core/Entities/Releases/Milestone.cs
@@ -34,7 +34,7 @@ namespace Hpe.Nga.Api.Core.Entities
 
         }
 
-        public Milestone(long id)
+        public Milestone(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Releases/Release.cs
+++ b/Hpe.Nga.Api.Core/Entities/Releases/Release.cs
@@ -35,7 +35,7 @@ namespace Hpe.Nga.Api.Core.Entities
 
         }
 
-        public Release(long id) : base(id)
+        public Release(EntityId id) : base(id)
         {
         }
 

--- a/Hpe.Nga.Api.Core/Entities/Releases/Sprint.cs
+++ b/Hpe.Nga.Api.Core/Entities/Releases/Sprint.cs
@@ -34,7 +34,7 @@ namespace Hpe.Nga.Api.Core.Entities
 
         }
 
-        public Sprint(long id)
+        public Sprint(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Requirements/Requirement.cs
+++ b/Hpe.Nga.Api.Core/Entities/Requirements/Requirement.cs
@@ -25,7 +25,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public Requirement(long id)
+        public Requirement(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Requirements/RequirementDocument.cs
+++ b/Hpe.Nga.Api.Core/Entities/Requirements/RequirementDocument.cs
@@ -24,7 +24,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public RequirementDocument(long id)
+        public RequirementDocument(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Tasks/Task.cs
+++ b/Hpe.Nga.Api.Core/Entities/Tasks/Task.cs
@@ -29,7 +29,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public Task(long id)
+        public Task(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Tests/Run.cs
+++ b/Hpe.Nga.Api.Core/Entities/Tests/Run.cs
@@ -28,7 +28,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public Run(long id)
+        public Run(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Tests/Test.cs
+++ b/Hpe.Nga.Api.Core/Entities/Tests/Test.cs
@@ -35,7 +35,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public Test(long id)
+        public Test(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Tests/TestGherkin.cs
+++ b/Hpe.Nga.Api.Core/Entities/Tests/TestGherkin.cs
@@ -24,7 +24,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public TestGherkin(long id)
+        public TestGherkin(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Tests/TestManual.cs
+++ b/Hpe.Nga.Api.Core/Entities/Tests/TestManual.cs
@@ -32,7 +32,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public TestManual(long id)
+        public TestManual(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/UserItems/UserItem.cs
+++ b/Hpe.Nga.Api.Core/Entities/UserItems/UserItem.cs
@@ -31,7 +31,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public UserItem(long id)
+        public UserItem(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Users/BaseUserEntity.cs
+++ b/Hpe.Nga.Api.Core/Entities/Users/BaseUserEntity.cs
@@ -34,7 +34,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public BaseUserEntity(long id)
+        public BaseUserEntity(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/Users/SharedSpaceUser.cs
+++ b/Hpe.Nga.Api.Core/Entities/Users/SharedSpaceUser.cs
@@ -35,7 +35,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public SharedspaceUser(long id)
+        public SharedspaceUser(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/WorkItems/Defect.cs
+++ b/Hpe.Nga.Api.Core/Entities/WorkItems/Defect.cs
@@ -30,7 +30,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public Defect(long id)
+        public Defect(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/WorkItems/Epic.cs
+++ b/Hpe.Nga.Api.Core/Entities/WorkItems/Epic.cs
@@ -31,7 +31,7 @@ namespace Hpe.Nga.Api.Core.Entities
 
         }
 
-        public Epic(long id)
+        public Epic(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/WorkItems/Feature.cs
+++ b/Hpe.Nga.Api.Core/Entities/WorkItems/Feature.cs
@@ -30,7 +30,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public Feature(long id)
+        public Feature(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/WorkItems/Story.cs
+++ b/Hpe.Nga.Api.Core/Entities/WorkItems/Story.cs
@@ -30,7 +30,7 @@ namespace Hpe.Nga.Api.Core.Entities
         {
         }
 
-        public Story(long id)
+        public Story(EntityId id)
             : base(id)
         {
         }

--- a/Hpe.Nga.Api.Core/Entities/WorkItems/WorkItem.cs
+++ b/Hpe.Nga.Api.Core/Entities/WorkItems/WorkItem.cs
@@ -45,7 +45,7 @@ namespace Hpe.Nga.Api.Core.Entities
             AggregateType = "work_item";
         }
 
-        public WorkItem(long id)
+        public WorkItem(EntityId id)
             : base(id)
         {
             AggregateType = "work_item";

--- a/Hpe.Nga.Api.Core/Hpe.Nga.Api.Core.csproj
+++ b/Hpe.Nga.Api.Core/Hpe.Nga.Api.Core.csproj
@@ -56,6 +56,8 @@
     <Compile Include="Connector\Exceptions\MqmRestException.cs" />
     <Compile Include="Connector\UserPassConnectionInfo.cs" />
     <Compile Include="Entities\Base\Attachment.cs" />
+    <Compile Include="Entities\Base\EntityIdExtensions.cs" />
+    <Compile Include="Entities\Base\EntityId.cs" />
     <Compile Include="Entities\Helpers\EntityHelper.cs" />
     <Compile Include="Entities\Requirements\Requirement.cs" />
     <Compile Include="Entities\Requirements\RequirementDocument.cs" />
@@ -87,6 +89,7 @@
     <Compile Include="Entities\Base\Workspace.cs" />
     <Compile Include="Entities\Users\WorkspaceUser.cs" />
     <Compile Include="Services\Attributes\CustomCollectionPathAttribute.cs" />
+    <Compile Include="Services\Core\EntityIdJsonConverter.cs" />
     <Compile Include="Services\EntityList.cs" />
     <Compile Include="Services\GenericEntityListResult.cs" />
     <Compile Include="Services\GroupBy\GroupResult.cs" />

--- a/Hpe.Nga.Api.Core/Services/Core/EntityIdJsonConverter.cs
+++ b/Hpe.Nga.Api.Core/Services/Core/EntityIdJsonConverter.cs
@@ -1,0 +1,112 @@
+﻿using Hpe.Nga.Api.Core.Entities;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Web.Script.Serialization;
+
+namespace Hpe.Nga.Api.Core.Services.Core
+{
+    /// <summary>
+    /// This class allow EntityId property to be serialized as plan string instead of complex JSON object.
+    /// </summary>
+    /// <remarks>
+    /// Workaround to serialize <see cref="EntityId"/> as simple string instead of a dictionary of keys and values.
+    /// For more details see http://blog.calyptus.eu/seb/2011/12/custom-datetime-json-serialization/.
+    /// </remarks>
+    internal partial class EntityIdJsonConverter : JavaScriptConverter
+    {
+        public override IEnumerable<Type> SupportedTypes
+        {
+            get
+            {
+                return new[] { typeof(EntityId) };
+            }
+        }
+
+        public override object Deserialize(IDictionary<string, object> dictionary, Type type, JavaScriptSerializer serializer)
+        {
+            return new JavaScriptSerializer().ConvertToType(dictionary, type);
+        }
+
+        public override IDictionary<string, object> Serialize(object obj, JavaScriptSerializer serializer)
+        {
+            if (!(obj is EntityId)) return null;
+
+            var entityId = (EntityId)obj;
+            return new EntityIdAsString(entityId.ToString());
+        }
+
+        private class EntityIdAsString : Uri, IDictionary<string, object>
+        {
+            public EntityIdAsString(string value) : base(value, UriKind.Relative)
+            {
+
+            }
+
+            public object this[string key] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public ICollection<string> Keys => throw new NotImplementedException();
+
+            public ICollection<object> Values => throw new NotImplementedException();
+
+            public int Count => throw new NotImplementedException();
+
+            public bool IsReadOnly => throw new NotImplementedException();
+
+            public void Add(string key, object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Add(KeyValuePair<string, object> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Contains(KeyValuePair<string, object> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool ContainsKey(string key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
+            {
+                throw new NotImplementedException();
+            }
+
+            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(string key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool Remove(KeyValuePair<string, object> item)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool TryGetValue(string key, out object value)
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/Hpe.Nga.Api.Core/Services/EntityService.cs
+++ b/Hpe.Nga.Api.Core/Services/EntityService.cs
@@ -44,7 +44,7 @@ namespace Hpe.Nga.Api.Core.Services
         {
             this.rc = rc;
             this.jsonSerializer = new JavaScriptSerializer();
-            jsonSerializer.RegisterConverters(new JavaScriptConverter[] { new BaseEntityJsonConverter() });
+            jsonSerializer.RegisterConverters(new JavaScriptConverter[] { new BaseEntityJsonConverter(), new EntityIdJsonConverter() });
         }
 
         public EntityListResult<T> Get<T>(IRequestContext context) where T : BaseEntity
@@ -132,7 +132,7 @@ namespace Hpe.Nga.Api.Core.Services
             return null;
         }
 
-        public async Task<TestScript> GetTestScriptAsync(IRequestContext context, long id)
+        public async Task<TestScript> GetTestScriptAsync(IRequestContext context, EntityId id)
         {
             string url = string.Format("{0}/tests/{1}/script", context.GetPath(), id);
             ResponseWrapper response = await rc.ExecuteGetAsync(url, string.Empty);
@@ -141,7 +141,7 @@ namespace Hpe.Nga.Api.Core.Services
             return result;
         }
 
-        public T GetById<T>(IRequestContext context, long id, IList<String> fields) where T : BaseEntity
+        public T GetById<T>(IRequestContext context, EntityId id, IList<String> fields) where T : BaseEntity
         {
             return GetResultOrThrowInnerException(GetByIdAsync<T>(context, id, fields));
         }
@@ -165,7 +165,7 @@ namespace Hpe.Nga.Api.Core.Services
             }
         }
 
-        public async Task<T> GetByIdAsync<T>(IRequestContext context, long id, IList<String> fields) where T : BaseEntity
+        public async Task<T> GetByIdAsync<T>(IRequestContext context, EntityId id, IList<String> fields) where T : BaseEntity
         {
             String collectionName = GetCollectionName<T>();
             string url = context.GetPath() + "/" + collectionName + "/" + id;
@@ -257,13 +257,13 @@ namespace Hpe.Nga.Api.Core.Services
             return result;
         }
 
-        public void DeleteById<T>(IRequestContext context, long entityId)
+        public void DeleteById<T>(IRequestContext context, EntityId entityId)
              where T : BaseEntity
         {
             DeleteByIdAsync<T>(context, entityId).Wait();
         }
 
-        public async Task DeleteByIdAsync<T>(IRequestContext context, long entityId)
+        public async Task DeleteByIdAsync<T>(IRequestContext context, EntityId entityId)
              where T : BaseEntity
         {
             String collectionName = GetCollectionName<T>();


### PR DESCRIPTION
Octane switch to using string as EntityId but since this SDK use long we are using a new type call EntityId that support implicit convertion to and from long and string.
There is Obsolete notice when using the long conversions which hopefully cause the SDK developers to switch to string.