### PR TITLE
Added support for add comments

### DIFF
--- a/OctaneSdk/Connector/RestConnector.cs
+++ b/OctaneSdk/Connector/RestConnector.cs
@@ -469,13 +469,11 @@ namespace MicroFocus.Adm.Octane.Api.Core.Connector
                 }
                 else
                 {
-                    awaitContinueOnCapturedContext = false;
                     request.ContentLength = byteData.Length;
                     using (Stream postStream = await request.GetRequestStreamAsync().ConfigureAwait(AwaitContinueOnCapturedContext))
                     {
                         postStream.Write(byteData, 0, byteData.Length);
                     }
-                    awaitContinueOnCapturedContext = true;
                 }
             }
 

--- a/OctaneSdk/Connector/RestConnector.cs
+++ b/OctaneSdk/Connector/RestConnector.cs
@@ -469,11 +469,13 @@ namespace MicroFocus.Adm.Octane.Api.Core.Connector
                 }
                 else
                 {
+                    awaitContinueOnCapturedContext = false;
                     request.ContentLength = byteData.Length;
                     using (Stream postStream = await request.GetRequestStreamAsync().ConfigureAwait(AwaitContinueOnCapturedContext))
                     {
                         postStream.Write(byteData, 0, byteData.Length);
                     }
+                    awaitContinueOnCapturedContext = true;
                 }
             }
 

--- a/OctaneSdk/Entities/Base/BaseEntity.cs
+++ b/OctaneSdk/Entities/Base/BaseEntity.cs
@@ -97,6 +97,10 @@ namespace MicroFocus.Adm.Octane.Api.Core.Entities
             {
                 return GetStringValue(TYPE_FIELD);
             }
+            set
+            {
+                SetValue(TYPE_FIELD, value);
+            }
 
         }
 

--- a/OctaneSdk/Entities/General/Comment.cs
+++ b/OctaneSdk/Entities/General/Comment.cs
@@ -46,7 +46,12 @@ namespace MicroFocus.Adm.Octane.Api.Core.Entities
         public BaseEntity OwnerWorkItem
         {
             get { return (BaseEntity)GetValue(OWNER_WORK_FIELD); }
+            set
+            {
+                SetValue(OWNER_WORK_FIELD, value);
+            }
         }
+
 
         public BaseEntity OwnerTest
         {
@@ -57,6 +62,7 @@ namespace MicroFocus.Adm.Octane.Api.Core.Entities
         {
             get { return (BaseEntity)GetValue(OWNER_RUN_FIELD); }
         }
+
 
         public BaseEntity OwnerRequirement
         {
@@ -71,6 +77,10 @@ namespace MicroFocus.Adm.Octane.Api.Core.Entities
         public string Text
         {
             get { return GetStringValue(TEXT_FIELD); }
+            set
+            {
+                SetValue(TEXT_FIELD, value);
+            }
         }
     }
 }

--- a/OctaneSdk/Services/EntityService.cs
+++ b/OctaneSdk/Services/EntityService.cs
@@ -191,9 +191,11 @@ namespace MicroFocus.Adm.Octane.Api.Core.Services
 
             string url = context.GetPath() + "/" + collectionName;
             String data = jsonSerializer.Serialize(entityList);
+
             ResponseWrapper response = await rc.ExecutePostAsync(url, queryParams, data).ConfigureAwait(RestConnector.AwaitContinueOnCapturedContext);
             EntityListResult<T> result = jsonSerializer.Deserialize<EntityListResult<T>>(response.Data);
             return result;
+
         }
 
         public T Create<T>(IRequestContext context, T entity, IList<string> fieldsToReturn = null) where T : BaseEntity


### PR DESCRIPTION
@radislavB I wanted to ask you about the awaitContinueOnCapturedContext - from what I read and understood, this bool in the ConfigureAwait() from the RestConnector.cs (line 474) waits for the threads to sync up, but in my case when trying to add a new comment, it would enter a deadlock - that is why I had to make the bool be false while going through that method. 

I've tested so that it does not break any updates we do on visual studio plugin, and it does not this way. I didn't find any other good way to try to avoid the deadlock happening. 

As for the other changes, just setters I need to set up a new comment and invoke the octane API.