### PR TITLE
Center issue

### DIFF
--- a/OctaneSdk/Connector/RestConnector.cs
+++ b/OctaneSdk/Connector/RestConnector.cs
@@ -127,9 +127,10 @@ namespace MicroFocus.Adm.Octane.Api.Core.Connector
                 streamWriter.Write(json);
             }
 
-            var httpResponse = (HttpWebResponse)await httpWebRequest.GetResponseAsync().ConfigureAwait(AwaitContinueOnCapturedContext);
-
-            SaveCookies(httpResponse);
+            using (var httpResponse = (HttpWebResponse)await httpWebRequest.GetResponseAsync().ConfigureAwait(AwaitContinueOnCapturedContext))
+            {
+                SaveCookies(httpResponse);
+            }
 
             return IsConnected();
         }
@@ -200,6 +201,17 @@ namespace MicroFocus.Adm.Octane.Api.Core.Connector
             return cookie.Value;
         }
 
+        public Task<ResponseWrapper> DisconnectAsync()
+        {
+            var resp = ExecutePostAsync(DISCONNECT_URL, null, null, null);
+            
+            // Reset cookies container to erase any existing cookies of the previous session.
+            lwSsoCookie = null;
+            octaneUserCookie = null;
+
+            return resp;
+        }
+
         public void Disconnect()
         {
             try
@@ -225,12 +237,12 @@ namespace MicroFocus.Adm.Octane.Api.Core.Connector
         private HttpWebRequest CreateRequest(string restRelativeUri, RequestType requestType, RequestConfiguration additionalRequestConfiguration)
         {
             String url = host + restRelativeUri;
-            HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create(url);
+            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
 
             //add cookies
             String cookieDomain = request.Address.Host;
             String cookiePath = "/";
-
+        
             request.CookieContainer = new CookieContainer();
             request.CookieContainer.Add(new Cookie(LWSSO_COOKIE_NAME, lwSsoCookie, cookiePath, cookieDomain));
             request.CookieContainer.Add(new Cookie(OCTANE_USER_COOKIE_NAME, octaneUserCookie, cookiePath, cookieDomain));

--- a/OctaneSdk/Connector/RestConnector.cs
+++ b/OctaneSdk/Connector/RestConnector.cs
@@ -203,21 +203,29 @@ namespace MicroFocus.Adm.Octane.Api.Core.Connector
 
         public Task<ResponseWrapper> DisconnectAsync()
         {
-            var resp = ExecutePostAsync(DISCONNECT_URL, null, null, null);
+            Task<ResponseWrapper> response = null;
+            try
+            {
+               response = ExecutePostAsync(DISCONNECT_URL, null, null, null);
+
+            }
+            catch (Exception)
+            {
+                // Do nothing
+            }
             
             // Reset cookies container to erase any existing cookies of the previous session.
             lwSsoCookie = null;
             octaneUserCookie = null;
 
-            return resp;
+            return response;
         }
 
         public void Disconnect()
         {
             try
             {
-                ResponseWrapper wrapper = ExecutePost(DISCONNECT_URL, null, null);
-
+                ResponseWrapper wrapper = DisconnectAsync().Result;
             }
             catch (Exception)
             {


### PR DESCRIPTION
New center link would cause the plugin to enter in a deadlock -> fix implies closing the httpwebrequest, otherwise .Net framework caches some data in the background and tries to reuse the last request to the same url, since that request was not disposed correctly it would hang the call -> entering in a deadlock

Defect id #694179: