### PR TITLE
adds setter for private varibales in order to pass the ci build

### DIFF
--- a/OctaneSdk/Services/Version/OctaneVersion.cs
+++ b/OctaneSdk/Services/Version/OctaneVersion.cs
@@ -11,8 +11,8 @@ namespace MicroFocus.Adm.Octane.Api.Core.Services.Version
 
         public static readonly OctaneVersion FENER_P3 = new OctaneVersion("12.55.7");
 
-        private string almVersion { get; }
-        private int octaneVersion { get; }
+        private string almVersion { get; set; }
+        private int octaneVersion { get; set; }
         private int buildNumber;
 
         public OctaneVersion(String versionString)


### PR DESCRIPTION
Ci build fails because of this error:
![image](https://user-images.githubusercontent.com/30106237/48193533-53a65300-e353-11e8-987a-76f5b6bcba3a.png)

In the code this is represented by:
![image](https://user-images.githubusercontent.com/30106237/48193669-abdd5500-e353-11e8-8a28-c31d3e678023.png)

As I've found at this link from stackoverflow the reason behind this issue is:
![stackoverflow](https://stackoverflow.com/questions/2597890/why-automatically-implemented-properties-must-define-both-get-and-set-accessors)

to which this seems to be the solution:

A more modern scenario for receiving this error is building code that uses C#6 syntax using a version of VisualStudio that is less than VS 2015 (or using MsBuild that is less than 14).

In C#6.0 it is allowable to have autoProperties that do not have a setter (they are assumed to be a private set).

Try compiling with VS2015+ or msbuild 14+ .. or modify the code so that all autoProperties have a setter.